### PR TITLE
Fix the 'A non well formed numeric value encountered' error

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -354,8 +354,11 @@ class Image extends AbstractImage
 
         $size = trim($size);
 
-        if (isset($map[substr($size, -2)])) {
-            $size = substr($size, 0, -2) * $map[substr($size, -2)];
+        $value = substr($size, 0, -2);
+        $unit = substr($size, -2);
+
+        if (isset($map[$unit]) && is_numeric($value)) {
+            $size = $value * $map[$unit];
         }
 
         if (is_numeric($size)) {

--- a/src/Image.php
+++ b/src/Image.php
@@ -355,7 +355,7 @@ class Image extends AbstractImage
         $size = trim($size);
 
         if (isset($map[substr($size, -2)])) {
-            $size = $size * $map[substr($size, -2)];
+            $size = substr($size, 0, -2) * $map[substr($size, -2)];
         }
 
         if (is_numeric($size)) {

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -423,8 +423,12 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             'in' => [(1 / 6).'in', 16],
             'cm' => [(2.54 / 6).'cm', 16],
             'mm' => [(25.4 / 6).'mm', 16],
+            'No unit with spacing' => [" \r \n \t 1234.5 \r \n \t ", 1235],
+            'em with spacing' => [" \r \n \t 1234.5em \r \n \t ", 19752],
             'unknown' => ['100vw', 0],
+            'unknown mmm' => ['1mmm', 0],
             'invalid' => ['abc', 0],
+            'invalid number' => ['12.34.5', 0],
         ];
     }
 


### PR DESCRIPTION
If `$size` is e.g. `600px`, then we need to strip `px` when recalculating the size, otherwise the code translates to `$size = 600px * 1`, which leads to a "A non well formed numeric value encountered" in PHP 7.1 (see https://travis-ci.org/contao/core-bundle/jobs/176963466).