### PR TITLE
[RTM] Implement effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ $imagine
     ->resize(new Box(40, 40))
     ->save('/path/to/thumbnail.svg')
 ;
+
+$image = $imagine->open('/path/to/image.svg');
+$image->effects()
+    ->gamma(1.5)
+    ->negative()
+    ->grayscale()
+    ->colorize($color)
+    ->sharpen()
+    ->blur(2)
+;
+$image->save('/path/to/image.svg');
 ```
 
 Because of the nature of SVG images, the `getSize()` method differs a little bit

--- a/src/Effects.php
+++ b/src/Effects.php
@@ -1,65 +1,252 @@
 <?php
 
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
 
 namespace Contao\ImagineSvg;
 
-
 use Imagine\Effects\EffectsInterface;
-use Imagine\Exception\RuntimeException;
+use Imagine\Exception\InvalidArgumentException;
+use Imagine\Exception\NotSupportedException;
 use Imagine\Image\Palette\Color\ColorInterface;
+use Imagine\Image\Palette\Color\RGB;
 
 class Effects implements EffectsInterface
 {
+    /**
+     * @var string
+     */
+    const SVG_FILTER_ID_PREFIX = 'svgImagineFilterV1_';
 
-    /** @var Image */
-    private $image;
+    /**
+     * @var \DOMDocument
+     */
+    private $document;
 
-    public function __construct(Image $image)
+    /**
+     * @param \DOMDocument $document
+     */
+    public function __construct(\DOMDocument $document)
     {
-        $this->image = $image;
+        $this->document = $document;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function gamma($correction)
     {
-        throw new RuntimeException('This method is not implemented');
+        $gamma = (float) $correction;
 
-        // TODO: Implement gamma() method.
+        if ($gamma <= 0) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid gamma correction value %s, must be a positive float or integer',
+                var_export($correction, true)
+            ));
+        }
+
+        $exponent = 1 / $gamma;
+
+        $this->addFilterElement('feComponentTransfer', [
+            ['feFuncR', [
+                'type' => 'gamma',
+                'exponent' => $exponent,
+            ]],
+            ['feFuncG', [
+                'type' => 'gamma',
+                'exponent' => $exponent,
+            ]],
+            ['feFuncB', [
+                'type' => 'gamma',
+                'exponent' => $exponent,
+            ]],
+        ]);
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function negative()
     {
-        throw new RuntimeException('This method is not implemented');
-        // TODO: Implement negative() method.
+        $this->addFilterElement('feColorMatrix', [
+            'type' => 'matrix',
+            'values' => implode(' ', [
+                '-1 0 0 0 1',
+                '0 -1 0 0 1',
+                '0 0 -1 0 1',
+                '0 0  0 1 0',
+            ]),
+        ]);
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function grayscale()
     {
-        throw new RuntimeException('This method is not implemented');
-        // TODO: Implement grayscale() method.
+        $this->addFilterElement('feColorMatrix', [
+            'type' => 'saturate',
+            'values' => '0',
+        ]);
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function colorize(ColorInterface $color)
     {
-        throw new RuntimeException('This method is not implemented');
-        // TODO: Implement colorize() method.
+        if (!$color instanceof RGB) {
+            throw new NotSupportedException('Colorize with non-rgb color is not supported');
+        }
+
+        $this->addFilterElement('feColorMatrix', [
+            'type' => 'matrix',
+            'values' => implode(' ', [
+                '1 0 0 0 '.json_encode($color->getRed() / 255),
+                '0 1 0 0 '.json_encode($color->getGreen() / 255),
+                '0 0 1 0 '.json_encode($color->getBlue() / 255),
+                '0 0 0 1 0',
+            ]),
+        ]);
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function sharpen()
     {
-        throw new RuntimeException('This method is not implemented');
-        // TODO: Implement sharpen() method.
+        $this->addFilterElement('feConvolveMatrix', [
+            'kernelMatrix' => implode(' ', [
+                '-0.02 -0.12 -0.02',
+                '-0.12  1.56 -0.12',
+                '-0.02 -0.12 -0.02',
+            ]),
+        ]);
+
+        return $this;
     }
 
-    public function blur($sigma)
+    /**
+     * {@inheritdoc}
+     */
+    public function blur($sigma = 1)
     {
+        $deviation = (float) $sigma;
 
-        $dom = $this->image->getDomDocument();
-        $dom->documentElement->setAttribute("filter", "url(#rokkaBlur)");
-        $filter = $dom->createDocumentFragment();
-        $filter->appendXML('<filter id="rokkaBlur">
-                <feGaussianBlur in="SourceGraphic" stdDeviation="'.$sigma.'" />
-        </filter>');
-        $dom->documentElement->insertBefore($filter, $dom->documentElement->firstChild);
+        if ($deviation <= 0) {
+            throw new InvalidArgumentException(sprintf(
+                'Invalid sigma %s, must be a positive float or integer',
+                var_export($sigma, true)
+            ));
+        }
+
+        $this->addFilterElement('feGaussianBlur', [
+            'stdDeviation' => json_encode($deviation),
+        ]);
+
+        return $this;
     }
 
+    /**
+     * Create and add a new filter element.
+     *
+     * @param string $name
+     * @param array  $attributes
+     */
+    private function addFilterElement($name, array $attributes)
+    {
+        $attributes['color-interpolation-filters'] = 'sRGB';
+
+        $this->getSvgFilter()->appendChild($this->createElement($name, $attributes));
+    }
+
+    /**
+     * Get the main filter element or create it if none is present.
+     *
+     * @return \DOMElement
+     */
+    private function getSvgFilter()
+    {
+        $svg = $this->document->documentElement;
+        $filter = null;
+
+        if (
+            1 === $svg->childNodes->length
+            && 'g' === $svg->firstChild->nodeName
+            && preg_match(
+                '/^url\(#('.self::SVG_FILTER_ID_PREFIX.'[0-9a-f]{16})\)$/',
+                (string) $svg->firstChild->getAttribute('filter'),
+                $matches
+            )
+        ) {
+            $id = $matches[1];
+        } else {
+            $this->wrapSvg();
+            $id = self::SVG_FILTER_ID_PREFIX.bin2hex(substr(hash('sha256', $this->document->saveXML()), 0, 8));
+            $svg->firstChild->setAttribute('filter', 'url(#'.$id.')');
+        }
+
+        foreach ($this->document->getElementsByTagName('filter') as $element) {
+            if ($element->getAttribute('id') === $id) {
+                return $element;
+            }
+        }
+
+        $filter = $this->document->createElement('filter');
+        $filter->setAttribute('id', $id);
+        $svg->firstChild->insertBefore($filter, $svg->firstChild->firstChild);
+
+        return $filter;
+    }
+
+    /**
+     * Add a group element that wraps all contents.
+     */
+    private function wrapSvg()
+    {
+        $svg = $this->document->documentElement;
+        $group = $this->document->createElement('g');
+
+        while ($svg->firstChild) {
+            $group->appendChild($svg->firstChild);
+        }
+
+        $svg->appendChild($group);
+    }
+
+    /**
+     * Create element with the specified attributes.
+     *
+     * @param string $name
+     * @param array  $attributes
+     *
+     * @return \DOMElement
+     */
+    private function createElement($name, array $attributes)
+    {
+        $filter = $this->document->createElement($name);
+
+        foreach ($attributes as $key => $value) {
+            if (is_string($key)) {
+                $filter->setAttribute($key, $value);
+            } else {
+                $filter->appendChild($this->createElement($value[0], $value[1]));
+            }
+        }
+
+        return $filter;
+    }
 }

--- a/src/Effects.php
+++ b/src/Effects.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace Contao\ImagineSvg;
+
+
+use Imagine\Effects\EffectsInterface;
+use Imagine\Exception\RuntimeException;
+use Imagine\Image\Palette\Color\ColorInterface;
+
+class Effects implements EffectsInterface
+{
+
+    /** @var Image */
+    private $image;
+
+    public function __construct(Image $image)
+    {
+        $this->image = $image;
+    }
+
+    public function gamma($correction)
+    {
+        throw new RuntimeException('This method is not implemented');
+
+        // TODO: Implement gamma() method.
+    }
+
+    public function negative()
+    {
+        throw new RuntimeException('This method is not implemented');
+        // TODO: Implement negative() method.
+    }
+
+    public function grayscale()
+    {
+        throw new RuntimeException('This method is not implemented');
+        // TODO: Implement grayscale() method.
+    }
+
+    public function colorize(ColorInterface $color)
+    {
+        throw new RuntimeException('This method is not implemented');
+        // TODO: Implement colorize() method.
+    }
+
+    public function sharpen()
+    {
+        throw new RuntimeException('This method is not implemented');
+        // TODO: Implement sharpen() method.
+    }
+
+    public function blur($sigma)
+    {
+
+        $dom = $this->image->getDomDocument();
+        $dom->documentElement->setAttribute("filter", "url(#rokkaBlur)");
+        $filter = $dom->createDocumentFragment();
+        $filter->appendXML('<filter id="rokkaBlur">
+                <feGaussianBlur in="SourceGraphic" stdDeviation="'.$sigma.'" />
+        </filter>');
+        $dom->documentElement->insertBefore($filter, $dom->documentElement->firstChild);
+    }
+
+}

--- a/src/Image.php
+++ b/src/Image.php
@@ -292,7 +292,7 @@ class Image extends AbstractImage
      */
     public function effects()
     {
-        throw new RuntimeException('This method is not implemented');
+        return new Effects($this);
     }
 
     /**

--- a/src/Image.php
+++ b/src/Image.php
@@ -292,7 +292,7 @@ class Image extends AbstractImage
      */
     public function effects()
     {
-        return new Effects($this);
+        return new Effects($this->document);
     }
 
     /**

--- a/tests/EffectsTest.php
+++ b/tests/EffectsTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\ImagineSvg\Tests;
+
+use Contao\ImagineSvg\Effects;
+use Contao\ImagineSvg\Imagine;
+use Contao\ImagineSvg\UndefinedBox;
+use Imagine\Exception\InvalidArgumentException;
+use Imagine\Exception\NotSupportedException;
+use Imagine\Image\Palette\Color\ColorInterface;
+use Imagine\Image\Palette\Color\RGB as ColorRgb;
+use Imagine\Image\Palette\RGB as PaletteRgb;
+use PHPUnit\Framework\TestCase;
+
+class EffectsTest extends TestCase
+{
+    public function testInstantiation()
+    {
+        $this->assertInstanceOf('Contao\ImagineSvg\Effects', new Effects(new \DOMDocument()));
+    }
+
+    public function testGamma()
+    {
+        $dom = (new Imagine())->create(new UndefinedBox())->getDomDocument();
+        $effects = new Effects($dom);
+
+        $this->assertSame($effects, $effects->gamma(1));
+        $this->assertTrue($dom->documentElement->firstChild->hasAttribute('filter'));
+
+        $filter = $dom->getElementsByTagName('filter')[0];
+        $filterId = explode(')', explode('#', $dom->documentElement->firstChild->getAttribute('filter'))[1])[0];
+
+        $this->assertSame($filterId, $filter->getAttribute('id'));
+        $this->assertSame('feComponentTransfer', $filter->firstChild->nodeName);
+        $this->assertSame('gamma', $filter->firstChild->firstChild->getAttribute('type'));
+        $this->assertSame('1', $filter->firstChild->firstChild->getAttribute('exponent'));
+
+        $effects->gamma(1.6);
+
+        $this->assertSame('url(#'.$filterId.')', $dom->documentElement->firstChild->getAttribute('filter'));
+        $this->assertSame(2, $filter->childNodes->length);
+        $this->assertSame('feComponentTransfer', $filter->lastChild->nodeName);
+        $this->assertSame('gamma', $filter->lastChild->firstChild->getAttribute('type'));
+        $this->assertSame('0.625', $filter->lastChild->firstChild->getAttribute('exponent'));
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $effects->gamma(0);
+    }
+
+    public function testNegative()
+    {
+        $dom = (new Imagine())->create(new UndefinedBox())->getDomDocument();
+        $effects = new Effects($dom);
+
+        $this->assertSame($effects, $effects->negative());
+        $this->assertTrue($dom->documentElement->firstChild->hasAttribute('filter'));
+
+        $filter = $dom->getElementsByTagName('filter')[0];
+        $filterId = explode(')', explode('#', $dom->documentElement->firstChild->getAttribute('filter'))[1])[0];
+
+        $this->assertSame($filterId, $filter->getAttribute('id'));
+        $this->assertSame('feColorMatrix', $filter->firstChild->nodeName);
+        $this->assertSame('matrix', $filter->firstChild->getAttribute('type'));
+        $this->assertSame([
+            '-1', '0', '0', '0', '1',
+            '0', '-1', '0', '0', '1',
+            '0', '0', '-1', '0', '1',
+            '0', '0',  '0', '1', '0',
+        ], preg_split('/\s+/', $filter->firstChild->getAttribute('values')));
+    }
+
+    public function testGrayscale()
+    {
+        $dom = (new Imagine())->create(new UndefinedBox())->getDomDocument();
+        $effects = new Effects($dom);
+
+        $this->assertSame($effects, $effects->grayscale());
+        $this->assertTrue($dom->documentElement->firstChild->hasAttribute('filter'));
+
+        $filter = $dom->getElementsByTagName('filter')[0];
+        $filterId = explode(')', explode('#', $dom->documentElement->firstChild->getAttribute('filter'))[1])[0];
+
+        $this->assertSame($filterId, $filter->getAttribute('id'));
+        $this->assertSame('feColorMatrix', $filter->firstChild->nodeName);
+        $this->assertSame('saturate', $filter->firstChild->getAttribute('type'));
+        $this->assertSame('0', $filter->firstChild->getAttribute('values'));
+    }
+
+    public function testColorize()
+    {
+        $dom = (new Imagine())->create(new UndefinedBox())->getDomDocument();
+        $effects = new Effects($dom);
+        $color = new ColorRgb(new PaletteRgb(), [255, 0, 0], 100);
+
+        $this->assertSame($effects, $effects->colorize($color));
+        $this->assertTrue($dom->documentElement->firstChild->hasAttribute('filter'));
+
+        $filter = $dom->getElementsByTagName('filter')[0];
+        $filterId = explode(')', explode('#', $dom->documentElement->firstChild->getAttribute('filter'))[1])[0];
+
+        $this->assertSame($filterId, $filter->getAttribute('id'));
+        $this->assertSame('feColorMatrix', $filter->firstChild->nodeName);
+        $this->assertSame('matrix', $filter->firstChild->getAttribute('type'));
+        $this->assertSame('1 0 0 0 1 0 1 0 0 0 0 0 1 0 0 0 0 0 1 0', $filter->firstChild->getAttribute('values'));
+
+        $color = new ColorRgb(new PaletteRgb(), [0, 255, 0], 100);
+        $effects->colorize($color);
+
+        $this->assertSame('url(#'.$filterId.')', $dom->documentElement->firstChild->getAttribute('filter'));
+        $this->assertSame(2, $filter->childNodes->length);
+        $this->assertSame('feColorMatrix', $filter->lastChild->nodeName);
+        $this->assertSame('matrix', $filter->lastChild->getAttribute('type'));
+        $this->assertSame('1 0 0 0 0 0 1 0 0 1 0 0 1 0 0 0 0 0 1 0', $filter->lastChild->getAttribute('values'));
+
+        $this->expectException(NotSupportedException::class);
+
+        $effects->colorize($this->createMock(ColorInterface::class));
+    }
+
+    public function testSharpen()
+    {
+        $dom = (new Imagine())->create(new UndefinedBox())->getDomDocument();
+        $effects = new Effects($dom);
+
+        $this->assertSame($effects, $effects->sharpen());
+        $this->assertTrue($dom->documentElement->firstChild->hasAttribute('filter'));
+
+        $filter = $dom->getElementsByTagName('filter')[0];
+        $filterId = explode(')', explode('#', $dom->documentElement->firstChild->getAttribute('filter'))[1])[0];
+
+        $this->assertSame($filterId, $filter->getAttribute('id'));
+        $this->assertSame('feConvolveMatrix', $filter->firstChild->nodeName);
+        $this->assertSame([
+            '-0.02', '-0.12', '-0.02',
+            '-0.12',  '1.56', '-0.12',
+            '-0.02', '-0.12', '-0.02',
+        ], preg_split('/\s+/', $filter->firstChild->getAttribute('kernelMatrix')));
+    }
+
+    public function testBlur()
+    {
+        $dom = (new Imagine())->create(new UndefinedBox())->getDomDocument();
+        $effects = new Effects($dom);
+
+        $this->assertSame($effects, $effects->blur(1.5));
+        $this->assertTrue($dom->documentElement->firstChild->hasAttribute('filter'));
+
+        $filter = $dom->getElementsByTagName('filter')[0];
+        $filterId = explode(')', explode('#', $dom->documentElement->firstChild->getAttribute('filter'))[1])[0];
+
+        $this->assertSame($filterId, $filter->getAttribute('id'));
+        $this->assertSame('feGaussianBlur', $filter->firstChild->nodeName);
+        $this->assertSame('1.5', $filter->firstChild->getAttribute('stdDeviation'));
+
+        $effects->blur();
+
+        $this->assertSame('url(#'.$filterId.')', $dom->documentElement->firstChild->getAttribute('filter'));
+        $this->assertSame(2, $filter->childNodes->length);
+        $this->assertSame('feGaussianBlur', $filter->lastChild->nodeName);
+        $this->assertSame('1', $filter->lastChild->getAttribute('stdDeviation'));
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $effects->blur(0);
+    }
+
+    public function testMultipleFilters()
+    {
+        $image = (new Imagine())->create(new UndefinedBox());
+        $dom = $image->getDomDocument();
+
+        $dom->documentElement->appendChild($dom->createElement('path'));
+
+        $image->effects()
+            ->gamma(1.5)
+            ->negative()
+            ->grayscale()
+            ->colorize(new ColorRgb(new PaletteRgb(), [255, 0, 0], 100))
+            ->sharpen()
+            ->blur(2)
+        ;
+
+        $this->assertTrue($dom->documentElement->firstChild->hasAttribute('filter'));
+
+        $filter = $dom->getElementsByTagName('filter')[0];
+        $filterId1 = explode(')', explode('#', $dom->documentElement->firstChild->getAttribute('filter'))[1])[0];
+
+        $this->assertSame($filterId1, $filter->getAttribute('id'));
+        $this->assertSame(6, $filter->childNodes->length);
+
+        $dom->documentElement->firstChild->setAttribute('filter', 'url(#differentId)');
+        $image->effects()->grayscale();
+
+        $this->assertTrue($dom->documentElement->firstChild->hasAttribute('filter'));
+
+        $filter = $dom->getElementsByTagName('filter')[0];
+        $filterId2 = explode(')', explode('#', $dom->documentElement->firstChild->getAttribute('filter'))[1])[0];
+
+        $this->assertNotSame($filterId1, $filterId2);
+        $this->assertSame($filterId2, $filter->getAttribute('id'));
+        $this->assertSame(1, $filter->childNodes->length);
+        $this->assertSame(2, $dom->getElementsByTagName('g')->length);
+        $this->assertSame('url(#differentId)', $dom->getElementsByTagName('g')[1]->getAttribute('filter'));
+    }
+}

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -10,9 +10,11 @@
 
 namespace Contao\ImagineSvg\Tests;
 
+use Contao\ImagineSvg\Effects;
 use Contao\ImagineSvg\Image;
 use Contao\ImagineSvg\Imagine;
 use Contao\ImagineSvg\RelativeBox;
+use Imagine\Effects\EffectsInterface;
 use Imagine\Exception\InvalidArgumentException;
 use Imagine\Exception\OutOfBoundsException;
 use Imagine\Exception\RuntimeException;
@@ -510,9 +512,8 @@ class ImageTest extends TestCase
     {
         $image = new Image(new \DOMDocument(), new MetadataBag());
 
-        $this->expectException(RuntimeException::class);
-
-        $image->effects();
+        $this->assertInstanceof(EffectsInterface::class, $image->effects());
+        $this->assertInstanceof(Effects::class, $image->effects());
     }
 
     public function testApplyMask()


### PR DESCRIPTION
Followup to #9

Implements all effects from the `Effects` interface.

Some notes about why certain things are implemented this way:

- Direct CSS filters like `filter: blur(1)` are not supported in SVG context in some browsers, so we have to use the `<filter>` element.
- Working around that by using `url()` with a data URI doesn’t work everywhere either.
- `filter` attribute on the main `<svg>` element is not supported in IE/Edge, this is why we are using a `<g>` wrapper.
- Multiple values for the `filter` attribute are not supported in some browsers, so we are using multiple elements in `<filter>`.
- To avoid duplicate IDs we generate them with ~~some random bytes~~ a hash of the SVG itself.