### PR TITLE
Use a double pipe as logical OR for the version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^5.6 || ^7.0",
         "ext-dom": "*",
-        "imagine/imagine": "^0.6|^0.7"
+        "imagine/imagine": "^0.6 || ^0.7"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.6",
         "phpunit/phpunit": "^5.7.26",
         "satooshi/php-coveralls": "^0.6",
-        "symfony/filesystem": "^2.8|^3.0|^4.0"
+        "symfony/filesystem": "^2.8 || ^3.0 || ^4.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
The single pipe `|` operator is considered deprecated but retained for backwards compatibility. For the logical OR version comparison, it is recommended to use the double pipe `||` operator in the `composer.json` as per the [official Composer documentation](https://getcomposer.org/doc/articles/versions.md#version-range).