### PR TITLE
Don’t throw exceptions for LIBXML warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+ * Don’t throw exceptions for LIBXML warnings. [#13]
 
 ## [0.2.2] (2019-01-27)
 
@@ -59,6 +60,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [0.1.1]: https://github.com/contao/imagine-svg/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/contao/imagine-svg/commits/0.1.0
 
+[#13]: https://github.com/contao/imagine-svg/issues/13
 [#10]: https://github.com/contao/imagine-svg/issues/10
 [#9]: https://github.com/contao/imagine-svg/issues/9
 [#8]: https://github.com/contao/imagine-svg/issues/8

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -125,7 +125,9 @@ class Imagine extends AbstractImagine
         if ($error = libxml_get_last_error()) {
             libxml_clear_errors();
 
-            throw new RuntimeException($error->message);
+            if (\in_array($error->level, [LIBXML_ERR_ERROR, LIBXML_ERR_FATAL], true)) {
+                throw new RuntimeException($error->message);
+            }
         }
 
         if ('svg' !== strtolower($document->documentElement->tagName)) {


### PR DESCRIPTION
LIBXML warnings like `xmlns: URI … is not absolute` should not be converted into exceptions.

The question is if we should trigger `E_WARNING` errors instead.

I think ignoring might be best, because if you have a “bad” SVG image in your installation you probably don’t want your logs to be filled with LIBXML warnings.

@contao/developers WDYT?