### PR TITLE
Use NotSupportedException if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
  * Don’t throw exceptions for LIBXML warnings. [#13]
  * Fix bug with viewBox computation.
+ * Use NotSupportedException if available. [#15]
 
 ## [0.2.2] (2019-01-27)
 
@@ -61,6 +62,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [0.1.1]: https://github.com/contao/imagine-svg/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/contao/imagine-svg/commits/0.1.0
 
+[#15]: https://github.com/contao/imagine-svg/issues/15
 [#13]: https://github.com/contao/imagine-svg/issues/13
 [#10]: https://github.com/contao/imagine-svg/issues/10
 [#9]: https://github.com/contao/imagine-svg/issues/9

--- a/src/Image.php
+++ b/src/Image.php
@@ -11,6 +11,7 @@
 namespace Contao\ImagineSvg;
 
 use Imagine\Exception\InvalidArgumentException;
+use Imagine\Exception\NotSupportedException;
 use Imagine\Exception\OutOfBoundsException;
 use Imagine\Exception\RuntimeException;
 use Imagine\Image\AbstractImage;
@@ -130,7 +131,7 @@ class Image extends AbstractImage
      */
     public function paste(ImageInterface $image, PointInterface $start, $alpha = 100)
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -167,7 +168,7 @@ class Image extends AbstractImage
      */
     public function rotate($angle, ColorInterface $background = null)
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -254,7 +255,7 @@ class Image extends AbstractImage
      */
     public function flipHorizontally()
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -262,7 +263,7 @@ class Image extends AbstractImage
      */
     public function flipVertically()
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -284,7 +285,7 @@ class Image extends AbstractImage
      */
     public function draw()
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -347,7 +348,7 @@ class Image extends AbstractImage
      */
     public function applyMask(ImageInterface $mask)
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -355,7 +356,7 @@ class Image extends AbstractImage
      */
     public function fill(FillInterface $fill)
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -363,7 +364,7 @@ class Image extends AbstractImage
      */
     public function mask()
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -371,7 +372,7 @@ class Image extends AbstractImage
      */
     public function histogram()
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -379,7 +380,7 @@ class Image extends AbstractImage
      */
     public function getColorAt(PointInterface $point)
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -387,7 +388,7 @@ class Image extends AbstractImage
      */
     public function layers()
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -395,7 +396,7 @@ class Image extends AbstractImage
      */
     public function interlace($scheme)
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -411,7 +412,7 @@ class Image extends AbstractImage
      */
     public function profile(ProfileInterface $profile)
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -481,5 +482,19 @@ class Image extends AbstractImage
         }
 
         return 0;
+    }
+
+    /**
+     * Returns a NotSupportedException for newer imagine version and RuntimeException for older versions.
+     *
+     * @return NotSupportedException|RuntimeException
+     */
+    private function createNotImplementedException()
+    {
+        if (class_exists(NotSupportedException::class)) {
+            return new NotSupportedException('This method is not implemented');
+        }
+
+        return new RuntimeException('This method is not implemented');
     }
 }

--- a/src/Image.php
+++ b/src/Image.php
@@ -421,7 +421,7 @@ class Image extends AbstractImage
     public function usePalette(PaletteInterface $palette)
     {
         if (!$palette instanceof RGB) {
-            throw new RuntimeException('SVG driver only supports RGB palette');
+            throw $this->createNotImplementedException('SVG driver only supports RGB palette');
         }
 
         $this->palette = $palette;
@@ -487,14 +487,16 @@ class Image extends AbstractImage
     /**
      * Returns a NotSupportedException for newer imagine version and RuntimeException for older versions.
      *
+     * @param string $message
+     *
      * @return NotSupportedException|RuntimeException
      */
-    private function createNotImplementedException()
+    private function createNotImplementedException($message = 'This method is not implemented')
     {
         if (class_exists(NotSupportedException::class)) {
-            return new NotSupportedException('This method is not implemented');
+            return new NotSupportedException($message);
         }
 
-        return new RuntimeException('This method is not implemented');
+        return new RuntimeException($message);
     }
 }

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -96,7 +96,11 @@ class Imagine extends AbstractImagine
      */
     public function font($file, $size, ColorInterface $color)
     {
-        throw $this->createNotImplementedException();
+        if (class_exists(NotSupportedException::class)) {
+            throw new NotSupportedException('This method is not implemented');
+        }
+
+        throw new RuntimeException('This method is not implemented');
     }
 
     /**
@@ -136,19 +140,5 @@ class Imagine extends AbstractImagine
         }
 
         return new Image($document, $metadata);
-    }
-
-    /**
-     * Returns a NotSupportedException for newer imagine version and RuntimeException for older versions.
-     *
-     * @return NotSupportedException|RuntimeException
-     */
-    private function createNotImplementedException()
-    {
-        if (class_exists(NotSupportedException::class)) {
-            return new NotSupportedException('This method is not implemented');
-        }
-
-        return new RuntimeException('This method is not implemented');
     }
 }

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -11,6 +11,7 @@
 namespace Contao\ImagineSvg;
 
 use Imagine\Exception\InvalidArgumentException;
+use Imagine\Exception\NotSupportedException;
 use Imagine\Exception\RuntimeException;
 use Imagine\Image\AbstractImagine;
 use Imagine\Image\BoxInterface;
@@ -95,7 +96,7 @@ class Imagine extends AbstractImagine
      */
     public function font($file, $size, ColorInterface $color)
     {
-        throw new RuntimeException('This method is not implemented');
+        throw $this->createNotImplementedException();
     }
 
     /**
@@ -135,5 +136,19 @@ class Imagine extends AbstractImagine
         }
 
         return new Image($document, $metadata);
+    }
+
+    /**
+     * Returns a NotSupportedException for newer imagine version and RuntimeException for older versions.
+     *
+     * @return NotSupportedException|RuntimeException
+     */
+    private function createNotImplementedException()
+    {
+        if (class_exists(NotSupportedException::class)) {
+            return new NotSupportedException('This method is not implemented');
+        }
+
+        return new RuntimeException('This method is not implemented');
     }
 }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -16,6 +16,7 @@ use Contao\ImagineSvg\Imagine;
 use Contao\ImagineSvg\RelativeBox;
 use Imagine\Effects\EffectsInterface;
 use Imagine\Exception\InvalidArgumentException;
+use Imagine\Exception\NotSupportedException;
 use Imagine\Exception\OutOfBoundsException;
 use Imagine\Exception\RuntimeException;
 use Imagine\Image\Box;
@@ -450,6 +451,10 @@ class ImageTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
+
         $image->paste(new Image(new \DOMDocument(), new MetadataBag()), new Point(0, 0));
     }
 
@@ -458,6 +463,10 @@ class ImageTest extends TestCase
         $image = new Image(new \DOMDocument(), new MetadataBag());
 
         $this->expectException(RuntimeException::class);
+
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
 
         $image->rotate(90);
     }
@@ -468,6 +477,10 @@ class ImageTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
+
         $image->flipHorizontally();
     }
 
@@ -476,6 +489,10 @@ class ImageTest extends TestCase
         $image = new Image(new \DOMDocument(), new MetadataBag());
 
         $this->expectException(RuntimeException::class);
+
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
 
         $image->flipVertically();
     }
@@ -523,6 +540,10 @@ class ImageTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
+
         $image->draw();
     }
 
@@ -540,6 +561,10 @@ class ImageTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
+
         $image->applyMask(new Image(new \DOMDocument(), new MetadataBag()));
     }
 
@@ -548,6 +573,10 @@ class ImageTest extends TestCase
         $image = new Image(new \DOMDocument(), new MetadataBag());
 
         $this->expectException(RuntimeException::class);
+
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
 
         $image->fill($this->createMock(FillInterface::class));
     }
@@ -558,6 +587,10 @@ class ImageTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
+
         $image->mask();
     }
 
@@ -566,6 +599,10 @@ class ImageTest extends TestCase
         $image = new Image(new \DOMDocument(), new MetadataBag());
 
         $this->expectException(RuntimeException::class);
+
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
 
         $image->histogram();
     }
@@ -576,6 +613,10 @@ class ImageTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
+
         $image->getColorAt(new Point(0, 0));
     }
 
@@ -585,6 +626,10 @@ class ImageTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
+
         $image->layers();
     }
 
@@ -593,6 +638,10 @@ class ImageTest extends TestCase
         $image = new Image(new \DOMDocument(), new MetadataBag());
 
         $this->expectException(RuntimeException::class);
+
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
 
         $image->interlace('');
     }
@@ -610,6 +659,10 @@ class ImageTest extends TestCase
 
         $this->expectException(RuntimeException::class);
 
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
+
         $image->profile($this->createMock(ProfileInterface::class));
     }
 
@@ -622,6 +675,10 @@ class ImageTest extends TestCase
         $this->assertSame($paletteRgb, $image->palette());
 
         $this->expectException(RuntimeException::class);
+
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
 
         $image->usePalette($this->createMock(PaletteInterface::class));
     }

--- a/tests/ImagineTest.php
+++ b/tests/ImagineTest.php
@@ -13,6 +13,7 @@ namespace Contao\ImagineSvg\Tests;
 use Contao\ImagineSvg\Imagine;
 use Contao\ImagineSvg\UndefinedBox;
 use Imagine\Exception\InvalidArgumentException;
+use Imagine\Exception\NotSupportedException;
 use Imagine\Exception\RuntimeException;
 use Imagine\Image\Box;
 use Imagine\Image\Palette\Color\ColorInterface;
@@ -241,6 +242,10 @@ class ImagineTest extends TestCase
         $color = $this->createMock(ColorInterface::class);
 
         $this->expectException(RuntimeException::class);
+
+        if (class_exists(NotSupportedException::class)) {
+            $this->expectException(NotSupportedException::class);
+        }
 
         $this->imagine->font($this->rootDir, 10, $color);
     }


### PR DESCRIPTION
If a adapter does not support a specific function since imagine 1.0 a NotSupportedException should be throw instead. As this does extend from the RuntimeException it will not be a bc break.