### PR TITLE
Fix `crop()`, `resize()` and `thumbnail()` for aspect ratio images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
  * Fix small pixel values for aspect ratio size. [#24]
+ * Fix `crop()`, `resize()` and `thumbnail()` for aspect ratio images. [#25]
 
 ## [1.0.0] (2020-06-13)
 
@@ -80,6 +81,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [0.1.1]: https://github.com/contao/imagine-svg/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/contao/imagine-svg/commits/0.1.0
 
+[#25]: https://github.com/contao/imagine-svg/issues/25
 [#24]: https://github.com/contao/imagine-svg/issues/24
 [#21]: https://github.com/contao/imagine-svg/issues/21
 [#19]: https://github.com/contao/imagine-svg/issues/19

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-dom": "*",
-        "imagine/imagine": "^1.0"
+        "imagine/imagine": "^1.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,3 @@ rules:
 
 parameters:
     ignoreErrors:
-        -
-            message: '#undefined method DOMNode::((has|get|set)Attribute|getElementsByTagName)\(\)#'
-            path: tests/EffectsTest.php

--- a/src/Image.php
+++ b/src/Image.php
@@ -196,7 +196,7 @@ class Image extends AbstractImage
         }
 
         $thumb = $settings & ImageInterface::THUMBNAIL_FLAG_NOCLONE ? $this : $this->copy();
-        $settings &= ~ImageInterface::THUMBNAIL_FLAG_NOCLONE;
+        $settings |= ImageInterface::THUMBNAIL_FLAG_NOCLONE;
 
         if (
             SvgBox::TYPE_ASPECT_RATIO === $newSizeType
@@ -208,7 +208,7 @@ class Image extends AbstractImage
                 $filter
             );
 
-            return $thumb->resize($size);
+            return $thumb->resize($size, $filter);
         }
 
         if (
@@ -216,7 +216,8 @@ class Image extends AbstractImage
             && SvgBox::TYPE_ASPECT_RATIO === $thumb->getSize()->getType()
         ) {
             $thumb->resize(
-                SvgBox::createTypeAbsolute($thumb->getSize()->getWidth(), $thumb->getSize()->getHeight())
+                SvgBox::createTypeAbsolute($thumb->getSize()->getWidth(), $thumb->getSize()->getHeight()),
+                $filter
             );
 
             return $thumb->thumbnail($size, $settings, $filter);
@@ -224,11 +225,12 @@ class Image extends AbstractImage
 
         if (SvgBox::TYPE_ASPECT_RATIO === $newSizeType) {
             return $thumb->resize(
-                SvgBox::createTypeAspectRatio($thumb->getSize()->getWidth(), $thumb->getSize()->getHeight())
+                SvgBox::createTypeAspectRatio($thumb->getSize()->getWidth(), $thumb->getSize()->getHeight()),
+                $filter
             );
         }
 
-        return $thumb->resize($size);
+        return $thumb->resize($size, $filter);
     }
 
     public function rotate($angle, ColorInterface $background = null): self

--- a/src/Image.php
+++ b/src/Image.php
@@ -341,34 +341,11 @@ class Image extends AbstractImage
      */
     private function normalizeRatio(float $a, float $b): array
     {
-        if ((float) (int) $a !== $a || (float) (int) $b !== $b) {
-            $maxDecimals = max($this->getFloatMultiplier($a), $this->getFloatMultiplier($b));
-            $a *= 10 ** $maxDecimals;
-            $b *= 10 ** $maxDecimals;
-
-            while ($a > PHP_INT_MAX || $b > PHP_INT_MAX) {
-                $a /= 10;
-                $b /= 10;
-            }
+        if ($a < $b) {
+            return [(int) round($a * 65535 / $b), 65535];
         }
 
-        $divisor = $this->getGreatestCommonDivisor((int) round($a), (int) round($b));
-
-        return [(int) ((int) $a / $divisor), (int) ((int) $b / $divisor)];
-    }
-
-    private function getFloatMultiplier(float $number): int
-    {
-        return ini_get('precision') - 1 - (int) explode('e', sprintf('%.0e', $number))[1];
-    }
-
-    private function getGreatestCommonDivisor(int $a, int $b): int
-    {
-        if (0 === $b) {
-            return $a;
-        }
-
-        return $this->getGreatestCommonDivisor($b, $a % $b);
+        return [65535, (int) round($b * 65535 / $a)];
     }
 
     /**

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -138,7 +138,7 @@ class ImageTest extends TestCase
         $this->assertSame(SvgBox::TYPE_ASPECT_RATIO, $image->getSize()->getType());
         $this->assertSame('100', $image->getDomDocument()->documentElement->firstChild->getAttribute('width'));
 
-        $image->crop(new Point(0, 0), new Box($image->getSize()->getWidth() / 2, $image->getSize()->getHeight() / 2));
+        $image->crop(new Point(0, 0), new Box(round($image->getSize()->getWidth() / 2), round($image->getSize()->getHeight() / 2)));
         $this->assertSame(SvgBox::TYPE_ABSOLUTE, $image->getSize()->getType());
         $this->assertSame($image->getSize()->getWidth(), (int) round($image->getDomDocument()->documentElement->firstChild->getAttribute('width') / 2));
 

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -363,12 +363,12 @@ class ImageTest extends TestCase
         $svg->removeAttribute('height');
 
         $this->assertSame(SvgBox::TYPE_ASPECT_RATIO, $image->getSize()->getType());
-        $this->assertSame(2.0, (float) ($image->getSize()->getWidth() / $image->getSize()->getHeight()));
+        $this->assertSame(2.0, round($image->getSize()->getWidth() / $image->getSize()->getHeight(), 4));
 
         $svg->setAttribute('viewBox', '0 0 1 0.5');
 
         $this->assertSame(SvgBox::TYPE_ASPECT_RATIO, $image->getSize()->getType());
-        $this->assertSame(2.0, (float) ($image->getSize()->getWidth() / $image->getSize()->getHeight()));
+        $this->assertSame(2.0, round($image->getSize()->getWidth() / $image->getSize()->getHeight(), 4));
 
         $svg->removeAttribute('viewBox');
 
@@ -402,7 +402,7 @@ class ImageTest extends TestCase
         $svg->setAttribute('viewBox', $viewBox);
 
         $this->assertSame(SvgBox::TYPE_ASPECT_RATIO, $image->getSize()->getType());
-        $this->assertSame($ratio, (float) ($image->getSize()->getWidth() / $image->getSize()->getHeight()));
+        $this->assertSame(round($ratio, 3), round($image->getSize()->getWidth() / $image->getSize()->getHeight(), 3));
     }
 
     public function getGetSizeAspectRatio(): array
@@ -418,7 +418,7 @@ class ImageTest extends TestCase
             ['0 0 1777777777777777777777777777777777777777 1000000000000000000000000000000000000000', 16 / 9],
             ['0 0 1.77777777777777777e50 1e50', 16 / 9],
             ['0 0 1.77777777777777777e-50 1e-50', 16 / 9],
-            ['0 0 10e5 10e4', 10.0 / 1],
+            ['0 0 13e5 10e4', 13.0 / 1],
         ];
     }
 


### PR DESCRIPTION
While working on #24 I realized that the methods `crop`, `resize` and `thumbnail` didn’t work for all use cases with aspect-ratio-sized images.

With these changes the sizing methods should work as expected now for every case I could think of.

cc @alexander-schranz

### ToDos

- [x] Add tests for the `thumbnail()` method.