### PR TITLE
Increase PHPStan level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
             - name: Analyze the code
               run: |
-                  vendor/bin/phpstan analyse src tests --level=5 --no-progress
+                  vendor/bin/phpstan analyse src tests --level=6 --no-progress
                   vendor/bin/psalm --no-suggestions --threads=4 --no-progress
 
     tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
             - name: Analyze the code
               run: |
-                  vendor/bin/phpstan analyse src tests --level=4 --no-progress
+                  vendor/bin/phpstan analyse src tests --level=5 --no-progress
                   vendor/bin/psalm --no-suggestions --threads=4 --no-progress
 
     tests:

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
             "vendor/bin/ecs check src tests --config vendor/contao/easy-coding-standard/config/default.yaml --fix --ansi"
         ],
         "phpstan": [
-            "vendor/bin/phpstan analyze src tests --level=4 --memory-limit=1G --ansi"
+            "vendor/bin/phpstan analyze src tests --level=6 --memory-limit=1G --ansi"
         ],
         "psalm": [
             "vendor/bin/psalm --no-suggestions --threads=4"

--- a/src/Effects.php
+++ b/src/Effects.php
@@ -175,6 +175,8 @@ class Effects implements EffectsInterface
 
     /**
      * Create and add a new filter element.
+     *
+     * @param array<string|int,string|array<string|array>> $attributes
      */
     private function addFilterElement(string $name, array $attributes): void
     {
@@ -241,6 +243,8 @@ class Effects implements EffectsInterface
 
     /**
      * Create element with the specified attributes.
+     *
+     * @param array<string|int,string|array<string|array>> $attributes
      */
     private function createElement(string $name, array $attributes): \DOMElement
     {

--- a/src/Image.php
+++ b/src/Image.php
@@ -41,6 +41,9 @@ class Image extends AbstractImage
      */
     private $palette;
 
+    /**
+     * @param MetadataBag<mixed> $metadata
+     */
     public function __construct(\DOMDocument $document, MetadataBag $metadata)
     {
         $this->document = $document;
@@ -145,6 +148,9 @@ class Image extends AbstractImage
         throw new NotSupportedException('This method is not implemented');
     }
 
+    /**
+     * @param array<string,string> $options
+     */
     public function save($path = null, array $options = []): self
     {
         if (null === $path && isset($this->metadata['filepath'])) {
@@ -177,6 +183,9 @@ class Image extends AbstractImage
         return $this;
     }
 
+    /**
+     * @param array<string,string> $options
+     */
     public function show($format, array $options = []): self
     {
         $image = $this->get($format, $options);
@@ -192,6 +201,9 @@ class Image extends AbstractImage
         return $this;
     }
 
+    /**
+     * @param array<string,string> $options
+     */
     public function get($format, array $options = []): string
     {
         $format = strtolower($format);
@@ -305,6 +317,9 @@ class Image extends AbstractImage
         throw new NotSupportedException('This method is not implemented');
     }
 
+    /**
+     * @return LayersInterface<ImageInterface>
+     */
     public function layers(): LayersInterface
     {
         throw new NotSupportedException('This method is not implemented');

--- a/src/Image.php
+++ b/src/Image.php
@@ -42,7 +42,8 @@ class Image extends AbstractImage
     private $palette;
 
     /**
-     * @param MetadataBag<mixed> $metadata
+     * @phpstan-param MetadataBag<mixed> $metadata
+     * @psalm-param MetadataBag $metadata
      */
     public function __construct(\DOMDocument $document, MetadataBag $metadata)
     {
@@ -149,7 +150,8 @@ class Image extends AbstractImage
     }
 
     /**
-     * @param array<string,string> $options
+     * @phpstan-param array<string,string> $options
+     * @psalm-param array $options
      */
     public function save($path = null, array $options = []): self
     {
@@ -184,7 +186,8 @@ class Image extends AbstractImage
     }
 
     /**
-     * @param array<string,string> $options
+     * @phpstan-param array<string,string> $options
+     * @psalm-param array $options
      */
     public function show($format, array $options = []): self
     {
@@ -202,7 +205,8 @@ class Image extends AbstractImage
     }
 
     /**
-     * @param array<string,string> $options
+     * @phpstan-param array<string,string> $options
+     * @psalm-param array $options
      */
     public function get($format, array $options = []): string
     {
@@ -318,7 +322,8 @@ class Image extends AbstractImage
     }
 
     /**
-     * @return LayersInterface<ImageInterface>
+     * @phpstan-return LayersInterface<ImageInterface>
+     * @psalm-return LayersInterface
      */
     public function layers(): LayersInterface
     {

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -87,7 +87,8 @@ class Imagine extends AbstractImagine
     /**
      * Returns an Image instance from an SVG string.
      *
-     * @param MetadataBag<mixed> $metadata
+     * @phpstan-param MetadataBag<mixed> $metadata
+     * @psalm-param MetadataBag $metadata
      */
     private function doLoad(string $data, MetadataBag $metadata): Image
     {

--- a/src/Imagine.php
+++ b/src/Imagine.php
@@ -86,6 +86,8 @@ class Imagine extends AbstractImagine
 
     /**
      * Returns an Image instance from an SVG string.
+     *
+     * @param MetadataBag<mixed> $metadata
      */
     private function doLoad(string $data, MetadataBag $metadata): Image
     {

--- a/tests/EffectsTest.php
+++ b/tests/EffectsTest.php
@@ -115,7 +115,7 @@ class EffectsTest extends TestCase
     {
         $dom = (new Imagine())->create(SvgBox::createTypeNone())->getDomDocument();
         $effects = new Effects($dom);
-        $color = new ColorRgb(new PaletteRgb(), [255, 127.5, 63.75], 100);
+        $color = new ColorRgb(new PaletteRgb(), [255, 51, 85], 100);
 
         $this->assertSame($effects, $effects->colorize($color));
         $this->assertTrue($dom->documentElement->firstChild->hasAttribute('filter'));
@@ -127,16 +127,16 @@ class EffectsTest extends TestCase
         $this->assertSame($filterId, $filter->getAttribute('id'));
         $this->assertSame('feColorMatrix', $filter->firstChild->nodeName);
         $this->assertSame('matrix', $filter->firstChild->getAttribute('type'));
-        $this->assertSame('1 0 0 0 1 0 1 0 0 0.5 0 0 1 0 0.25 0 0 0 1 0', $filter->firstChild->getAttribute('values'));
+        $this->assertSame('1 0 0 0 1 0 1 0 0 0.2 0 0 1 0 0.3333333 0 0 0 1 0', $filter->firstChild->getAttribute('values'));
 
-        $color = new ColorRgb(new PaletteRgb(), [63.75, 255, 127.5], 100);
+        $color = new ColorRgb(new PaletteRgb(), [51, 255, 85], 100);
         $effects->colorize($color);
 
         $this->assertSame('url(#'.$filterId.')', $dom->documentElement->firstChild->getAttribute('filter'));
         $this->assertSame(2, $filter->childNodes->length);
         $this->assertSame('feColorMatrix', $filter->lastChild->nodeName);
         $this->assertSame('matrix', $filter->lastChild->getAttribute('type'));
-        $this->assertSame('1 0 0 0 0.25 0 1 0 0 1 0 0 1 0 0.5 0 0 0 1 0', $filter->lastChild->getAttribute('values'));
+        $this->assertSame('1 0 0 0 0.2 0 1 0 0 1 0 0 1 0 0.3333333 0 0 0 1 0', $filter->lastChild->getAttribute('values'));
 
         $this->expectException(NotSupportedException::class);
 
@@ -172,7 +172,7 @@ class EffectsTest extends TestCase
         $dom = (new Imagine())->create(SvgBox::createTypeNone())->getDomDocument();
         $effects = new Effects($dom);
 
-        $this->assertSame($effects, $effects->blur(' 1.50'));
+        $this->assertSame($effects, $effects->blur(1.5));
         $this->assertTrue($dom->documentElement->firstChild->hasAttribute('filter'));
 
         /** @var \DOMElement $filter */
@@ -345,7 +345,7 @@ class EffectsTest extends TestCase
 
     private function executeTestWithLocale(string $methodName): void
     {
-        $locale = setlocale(LC_NUMERIC, 0);
+        $locale = setlocale(LC_NUMERIC, '0');
 
         if (false === $locale) {
             $this->markTestSkipped('Your platform does not support locales.');

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -367,7 +367,7 @@ class ImageTest extends TestCase
 
         $svg->setAttribute('viewBox', '0 0 1 0.5');
 
-        $this->assertSame(SvgBox::TYPE_ASPECT_RATIO, $image->getSize()->getType());
+        $this->assertSame(0 + SvgBox::TYPE_ASPECT_RATIO, $image->getSize()->getType());
         $this->assertSame(2.0, round($image->getSize()->getWidth() / $image->getSize()->getHeight(), 4));
 
         $svg->removeAttribute('viewBox');
@@ -378,14 +378,14 @@ class ImageTest extends TestCase
 
         $svg->setAttribute('width', '100');
 
-        $this->assertSame(SvgBox::TYPE_NONE, $image->getSize()->getType());
+        $this->assertSame(0 + SvgBox::TYPE_NONE, $image->getSize()->getType());
         $this->assertSame(300, $image->getSize()->getWidth());
         $this->assertSame(150, $image->getSize()->getHeight());
 
         $svg->removeAttribute('width');
         $svg->setAttribute('height', '100');
 
-        $this->assertSame(SvgBox::TYPE_NONE, $image->getSize()->getType());
+        $this->assertSame(0 + SvgBox::TYPE_NONE, $image->getSize()->getType());
         $this->assertSame(300, $image->getSize()->getWidth());
         $this->assertSame(150, $image->getSize()->getHeight());
     }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -405,6 +405,9 @@ class ImageTest extends TestCase
         $this->assertSame(round($ratio, 3), round($image->getSize()->getWidth() / $image->getSize()->getHeight(), 3));
     }
 
+    /**
+     * @return array<array<string|float>>
+     */
     public function getGetSizeAspectRatio(): array
     {
         return [
@@ -443,6 +446,9 @@ class ImageTest extends TestCase
         }
     }
 
+    /**
+     * @return array<string,array<string|float|int|null>>
+     */
     public function getGetSizePixelValues(): array
     {
         return [
@@ -513,6 +519,9 @@ class ImageTest extends TestCase
         $this->assertSame($expected, $image->get('svg'));
     }
 
+    /**
+     * @return array<string,array<string>>
+     */
     public function getStrip(): array
     {
         return [

--- a/tests/ImagineTest.php
+++ b/tests/ImagineTest.php
@@ -232,7 +232,7 @@ class ImagineTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        /* @noinspection PhpParamsInspection */
+        /** @phpstan-ignore-next-line */
         $this->imagine->read('not a resource');
     }
 

--- a/tests/ImagineTest.php
+++ b/tests/ImagineTest.php
@@ -232,7 +232,7 @@ class ImagineTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        /** @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line */
         $this->imagine->read('not a resource');
     }
 


### PR DESCRIPTION
~~Level 6 seems impossible because psalm fights the changes required for phpstan.~~ Fixed by adding `@phpstan-` and `@psalm-` type annotations.

But the level 5 changes can be used I think.

/cc @m-vo