### PR TITLE
Do not throw exceptions for invalid resize filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
  * Correctly handle XML namespaces. [#39]
+ * Do not throw exceptions for invalid resize filters. [#42]
 
 ## [1.0.3] (2021-08-10)
 
@@ -96,6 +97,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [0.1.1]: https://github.com/contao/imagine-svg/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/contao/imagine-svg/commits/0.1.0
 
+[#42]: https://github.com/contao/imagine-svg/issues/42
 [#39]: https://github.com/contao/imagine-svg/issues/39
 [#33]: https://github.com/contao/imagine-svg/issues/33
 [#28]: https://github.com/contao/imagine-svg/issues/28

--- a/src/Image.php
+++ b/src/Image.php
@@ -150,10 +150,6 @@ class Image extends AbstractImage
 
     public function resize(BoxInterface $size, $filter = ImageInterface::FILTER_UNDEFINED): self
     {
-        if (ImageInterface::FILTER_UNDEFINED !== $filter) {
-            throw new InvalidArgumentException('Unsupported filter type, SVG only supports ImageInterface::FILTER_UNDEFINED filter');
-        }
-
         $currentSize = $this->getSize();
         $newSizeType = $size instanceof SvgBox ? $size->getType() : SvgBox::TYPE_ABSOLUTE;
 

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -258,9 +258,8 @@ class ImageTest extends TestCase
 
         $this->assertSame(SvgBox::TYPE_NONE, $image->getSize()->getType());
 
-        $this->expectException(InvalidArgumentException::class);
-
-        $image->resize(new Box(25, 25), ImageInterface::FILTER_POINT);
+        // Unsupported filters should not throw, same behavior as GD
+        $image->resize(new Box(25, 25), ImageInterface::FILTER_LANCZOS);
     }
 
     public function testThumbnail(): void
@@ -373,8 +372,7 @@ class ImageTest extends TestCase
 
         $this->assertSame(SvgBox::TYPE_NONE, $image->getSize()->getType());
 
-        $this->expectException(InvalidArgumentException::class);
-
+        // Unsupported filters should not throw, same behavior as GD
         $image->thumbnail(new Box(25, 25), ImageInterface::THUMBNAIL_FLAG_NOCLONE, ImageInterface::FILTER_POINT);
     }
 


### PR DESCRIPTION
See also https://github.com/php-imagine/Imagine/blob/93bdd9ad420bfbf2aa5c33fe70d134b3c9cc081b/src/Gd/Image.php#L202
See also https://github.com/contao/image/issues/107#issuecomment-2348405948